### PR TITLE
Update doc

### DIFF
--- a/docs/rules/spaced-comment.md
+++ b/docs/rules/spaced-comment.md
@@ -33,13 +33,17 @@ This rule will enforce consistency of spacing after the start of a comment `#`. 
 ESLint core `spaced-comment` rule don't work well in YAML. Turn off that rule in YAML files and use `yml/spaced-comment` rule.  
 Use the `overrides` setting to apply these only to YAML files:
 
-```yaml
-overrides: 
-  - 
-    files: ["*.yaml", "*.yml"]
-    rules: 
-        spaced-comment: off
-        yml/spaced-comment: error
+```js
+overrides: [
+  {
+    files: ['*.yaml', '*.yml'],
+    parser: 'yaml-eslint-parser',
+    rules: {
+      'spaced-comment': ['off'],
+      'yml/spaced-comment': ['error']
+    }
+  }
+],
 ```
 
 ## :wrench: Options

--- a/docs/rules/spaced-comment.md
+++ b/docs/rules/spaced-comment.md
@@ -34,16 +34,18 @@ ESLint core `spaced-comment` rule don't work well in YAML. Turn off that rule in
 Use the `overrides` setting to apply these only to YAML files:
 
 ```js
-overrides: [
-  {
-    files: ['*.yaml', '*.yml'],
-    parser: 'yaml-eslint-parser',
-    rules: {
-      'spaced-comment': ['off'],
-      'yml/spaced-comment': ['error']
-    }
-  }
-],
+module.exports = {
+  overrides: [
+    {
+      files: ["*.yaml", "*.yml"],
+      parser: "yaml-eslint-parser",
+      rules: {
+        "spaced-comment": ["off"],
+        "yml/spaced-comment": ["error"],
+      },
+    },
+  ],
+};
 ```
 
 ## :wrench: Options


### PR DESCRIPTION
Follow-up to: https://github.com/ota-meshi/eslint-plugin-yml/issues/91

Update `yml/spaced-comment` example from _yaml_ to _js_ for `eslintrc.js`.

Snippet now works in `eslintrc.js`.

Feel free to close PR if docs sticking to _yaml_ syntax.

Cheers