### PR TITLE
fixed: disable "no-unused-vars"

### DIFF
--- a/.changeset/chilled-cobras-protect.md
+++ b/.changeset/chilled-cobras-protect.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-yml": minor
+---
+
+disable `no-unused-vars` in base config

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -7,6 +7,7 @@ export = {
       rules: {
         // ESLint core rules known to cause problems with YAML.
         "no-irregular-whitespace": "off",
+        "no-unused-vars": "off",
         "spaced-comment": "off",
       },
     },


### PR DESCRIPTION
Fixes #204 - false positives in comments starting with the word "global"