### PR TITLE
fix(docs): incorrect option in `yml/flow-sequence-bracket-newline`

### DIFF
--- a/docs/rules/flow-sequence-bracket-newline.md
+++ b/docs/rules/flow-sequence-bracket-newline.md
@@ -50,6 +50,10 @@ This rule enforces line breaks after opening and before closing flow sequence br
 yml/flow-sequence-bracket-newline:
   - error
   - always # or "never" or "consistent"
+---
+# or
+yml/flow-sequence-bracket-newline:
+  - error
   - multiline: true
     minItems: null
 ```


### PR DESCRIPTION
`yml/flow-sequence-bracket-newline` accepts one (string | object) option

Fixes #340