### PR TITLE
refactor: drop lodash

### DIFF
--- a/.changeset/vast-coats-rest.md
+++ b/.changeset/vast-coats-rest.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-yml": patch
+---
+
+Replace `lodash` to reduce the package installation size

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
   "homepage": "https://ota-meshi.github.io/eslint-plugin-yml/",
   "dependencies": {
     "debug": "^4.3.2",
+    "escape-string-regexp": "4.0.0",
     "eslint-compat-utils": "^0.6.0",
-    "lodash": "^4.17.21",
     "natural-compare": "^1.4.0",
     "yaml-eslint-parser": "^1.2.1"
   },
@@ -80,7 +80,6 @@
     "@types/eslint-scope": "^3.7.0",
     "@types/eslint-visitor-keys": "^3.0.0",
     "@types/estree": "^1.0.0",
-    "@types/lodash": "^4.14.158",
     "@types/mocha": "^10.0.0",
     "@types/natural-compare": "^1.4.0",
     "@types/node": "^22.0.0",

--- a/src/rules/spaced-comment.ts
+++ b/src/rules/spaced-comment.ts
@@ -1,5 +1,5 @@
 import type { AST } from "yaml-eslint-parser";
-import lodash from "lodash";
+import escapeStringRegexp from "escape-string-regexp";
 import { createRule } from "../utils/index";
 import { getSourceCode } from "../utils/compat";
 
@@ -13,7 +13,7 @@ import { getSourceCode } from "../utils/compat";
  * @returns {string} An escaped string.
  */
 function escapeText(s: string) {
-  return `(?:${lodash.escapeRegExp(s)})`;
+  return `(?:${escapeStringRegexp(s)})`;
 }
 
 /**


### PR DESCRIPTION
We don't need an entire `lodash` library to just escape regexp.

Replace `lodash` with `escape-string-regexp`.

All tests passed locally on my machine.

<img width="1402" alt="image" src="https://github.com/user-attachments/assets/abdbf736-6ff2-4b23-bfa0-a05829425030" />
