### PR TITLE
feat: add stylistic config

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ This plugin provides configs:
 - `*.configs['flat/base']` ... Configuration to enable correct YAML parsing.
 - `*.configs['flat/recommended']` ... Above, plus rules to prevent errors or unintended behavior.
 - `*.configs['flat/standard']` ... Above, plus rules to enforce the common stylistic conventions.
+- `*.configs['flat/stylistic']` ... Rules to enforce additional opinionated stylistic conventions.
 - `*.configs['flat/prettier']` ... Turn off rules that may conflict with [Prettier](https://prettier.io/).
 
 See [the rule list](https://ota-meshi.github.io/eslint-plugin-yml/rules/) to get the `rules` that this plugin provides.
@@ -120,6 +121,7 @@ This plugin provides configs:
 - `plugin:yml/base` ... Configuration to enable correct YAML parsing.
 - `plugin:yml/recommended` ... Above, plus rules to prevent errors or unintended behavior.
 - `plugin:yml/standard` ... Above, plus rules to enforce the common stylistic conventions.
+- `plugin:yml/stylistic` ... Rules to enforce additional opinionated stylistic conventions.
 - `plugin:yml/prettier` ... Turn off rules that may conflict with [Prettier](https://prettier.io/).
 
 See [the rule list](https://ota-meshi.github.io/eslint-plugin-yml/rules/) to get the `rules` that this plugin provides.
@@ -229,41 +231,47 @@ The rules with the following star :star: are included in the config.
 
 ### YAML Rules
 
-| Rule ID | Description | Fixable | RECOMMENDED | STANDARD |
-|:--------|:------------|:-------:|:-----------:|:--------:|
-| [yml/block-mapping-colon-indicator-newline](https://ota-meshi.github.io/eslint-plugin-yml/rules/block-mapping-colon-indicator-newline.html) | enforce consistent line breaks after `:` indicator | :wrench: |  |  |
-| [yml/block-mapping-question-indicator-newline](https://ota-meshi.github.io/eslint-plugin-yml/rules/block-mapping-question-indicator-newline.html) | enforce consistent line breaks after `?` indicator | :wrench: |  | :star: |
-| [yml/block-mapping](https://ota-meshi.github.io/eslint-plugin-yml/rules/block-mapping.html) | require or disallow block style mappings. | :wrench: |  | :star: |
-| [yml/block-sequence-hyphen-indicator-newline](https://ota-meshi.github.io/eslint-plugin-yml/rules/block-sequence-hyphen-indicator-newline.html) | enforce consistent line breaks after `-` indicator | :wrench: |  | :star: |
-| [yml/block-sequence](https://ota-meshi.github.io/eslint-plugin-yml/rules/block-sequence.html) | require or disallow block style sequences. | :wrench: |  | :star: |
-| [yml/file-extension](https://ota-meshi.github.io/eslint-plugin-yml/rules/file-extension.html) | enforce YAML file extension |  |  |  |
-| [yml/indent](https://ota-meshi.github.io/eslint-plugin-yml/rules/indent.html) | enforce consistent indentation | :wrench: |  | :star: |
-| [yml/key-name-casing](https://ota-meshi.github.io/eslint-plugin-yml/rules/key-name-casing.html) | enforce naming convention to key names |  |  |  |
-| [yml/no-empty-document](https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-document.html) | disallow empty document |  | :star: | :star: |
-| [yml/no-empty-key](https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-key.html) | disallow empty mapping keys |  | :star: | :star: |
-| [yml/no-empty-mapping-value](https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-mapping-value.html) | disallow empty mapping values |  | :star: | :star: |
-| [yml/no-empty-sequence-entry](https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-sequence-entry.html) | disallow empty sequence entries |  | :star: | :star: |
-| [yml/no-tab-indent](https://ota-meshi.github.io/eslint-plugin-yml/rules/no-tab-indent.html) | disallow tabs for indentation. |  | :star: | :star: |
-| [yml/no-trailing-zeros](https://ota-meshi.github.io/eslint-plugin-yml/rules/no-trailing-zeros.html) | disallow trailing zeros for floats | :wrench: |  |  |
-| [yml/plain-scalar](https://ota-meshi.github.io/eslint-plugin-yml/rules/plain-scalar.html) | require or disallow plain style scalar. | :wrench: |  | :star: |
-| [yml/quotes](https://ota-meshi.github.io/eslint-plugin-yml/rules/quotes.html) | enforce the consistent use of either double, or single quotes | :wrench: |  | :star: |
-| [yml/require-string-key](https://ota-meshi.github.io/eslint-plugin-yml/rules/require-string-key.html) | disallow mapping keys other than strings |  |  |  |
-| [yml/sort-keys](https://ota-meshi.github.io/eslint-plugin-yml/rules/sort-keys.html) | require mapping keys to be sorted | :wrench: |  |  |
-| [yml/sort-sequence-values](https://ota-meshi.github.io/eslint-plugin-yml/rules/sort-sequence-values.html) | require sequence values to be sorted | :wrench: |  |  |
-| [yml/vue-custom-block/no-parsing-error](https://ota-meshi.github.io/eslint-plugin-yml/rules/vue-custom-block/no-parsing-error.html) | disallow parsing errors in Vue custom blocks |  | :star: | :star: |
+Category emojis:
+
+- :star: - recommended
+- :star2: - standard
+- :art: - stylistic
+
+| Rule ID | Description | Fixable | Configurations |
+|:--------|:------------|:-------:|:--------------:|
+| [yml/block-mapping-colon-indicator-newline](https://ota-meshi.github.io/eslint-plugin-yml/rules/block-mapping-colon-indicator-newline.html) | enforce consistent line breaks after `:` indicator | :wrench: |  |
+| [yml/block-mapping-question-indicator-newline](https://ota-meshi.github.io/eslint-plugin-yml/rules/block-mapping-question-indicator-newline.html) | enforce consistent line breaks after `?` indicator | :wrench: | :star2: |
+| [yml/block-mapping](https://ota-meshi.github.io/eslint-plugin-yml/rules/block-mapping.html) | require or disallow block style mappings. | :wrench: | :star2: |
+| [yml/block-sequence-hyphen-indicator-newline](https://ota-meshi.github.io/eslint-plugin-yml/rules/block-sequence-hyphen-indicator-newline.html) | enforce consistent line breaks after `-` indicator | :wrench: | :star2: |
+| [yml/block-sequence](https://ota-meshi.github.io/eslint-plugin-yml/rules/block-sequence.html) | require or disallow block style sequences. | :wrench: | :star2: |
+| [yml/file-extension](https://ota-meshi.github.io/eslint-plugin-yml/rules/file-extension.html) | enforce YAML file extension |  | :art: |
+| [yml/indent](https://ota-meshi.github.io/eslint-plugin-yml/rules/indent.html) | enforce consistent indentation | :wrench: | :star2: |
+| [yml/key-name-casing](https://ota-meshi.github.io/eslint-plugin-yml/rules/key-name-casing.html) | enforce naming convention to key names |  |  |
+| [yml/no-empty-document](https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-document.html) | disallow empty document |  | :star: :star2: |
+| [yml/no-empty-key](https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-key.html) | disallow empty mapping keys |  | :star: :star2: |
+| [yml/no-empty-mapping-value](https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-mapping-value.html) | disallow empty mapping values |  | :star: :star2: |
+| [yml/no-empty-sequence-entry](https://ota-meshi.github.io/eslint-plugin-yml/rules/no-empty-sequence-entry.html) | disallow empty sequence entries |  | :star: :star2: |
+| [yml/no-tab-indent](https://ota-meshi.github.io/eslint-plugin-yml/rules/no-tab-indent.html) | disallow tabs for indentation. |  | :star: :star2: |
+| [yml/no-trailing-zeros](https://ota-meshi.github.io/eslint-plugin-yml/rules/no-trailing-zeros.html) | disallow trailing zeros for floats | :wrench: |  |
+| [yml/plain-scalar](https://ota-meshi.github.io/eslint-plugin-yml/rules/plain-scalar.html) | require or disallow plain style scalar. | :wrench: | :star2: |
+| [yml/quotes](https://ota-meshi.github.io/eslint-plugin-yml/rules/quotes.html) | enforce the consistent use of either double, or single quotes | :wrench: | :star2: |
+| [yml/require-string-key](https://ota-meshi.github.io/eslint-plugin-yml/rules/require-string-key.html) | disallow mapping keys other than strings |  | :art: |
+| [yml/sort-keys](https://ota-meshi.github.io/eslint-plugin-yml/rules/sort-keys.html) | require mapping keys to be sorted | :wrench: | :art: |
+| [yml/sort-sequence-values](https://ota-meshi.github.io/eslint-plugin-yml/rules/sort-sequence-values.html) | require sequence values to be sorted | :wrench: | :art: |
+| [yml/vue-custom-block/no-parsing-error](https://ota-meshi.github.io/eslint-plugin-yml/rules/vue-custom-block/no-parsing-error.html) | disallow parsing errors in Vue custom blocks |  | :star: :star2: |
 
 ### Extension Rules
 
-| Rule ID | Description | Fixable | RECOMMENDED | STANDARD |
-|:--------|:------------|:-------:|:-----------:|:--------:|
-| [yml/flow-mapping-curly-newline](https://ota-meshi.github.io/eslint-plugin-yml/rules/flow-mapping-curly-newline.html) | enforce consistent line breaks inside braces | :wrench: |  | :star: |
-| [yml/flow-mapping-curly-spacing](https://ota-meshi.github.io/eslint-plugin-yml/rules/flow-mapping-curly-spacing.html) | enforce consistent spacing inside braces | :wrench: |  | :star: |
-| [yml/flow-sequence-bracket-newline](https://ota-meshi.github.io/eslint-plugin-yml/rules/flow-sequence-bracket-newline.html) | enforce linebreaks after opening and before closing flow sequence brackets | :wrench: |  | :star: |
-| [yml/flow-sequence-bracket-spacing](https://ota-meshi.github.io/eslint-plugin-yml/rules/flow-sequence-bracket-spacing.html) | enforce consistent spacing inside flow sequence brackets | :wrench: |  | :star: |
-| [yml/key-spacing](https://ota-meshi.github.io/eslint-plugin-yml/rules/key-spacing.html) | enforce consistent spacing between keys and values in mapping pairs | :wrench: |  | :star: |
-| [yml/no-irregular-whitespace](https://ota-meshi.github.io/eslint-plugin-yml/rules/no-irregular-whitespace.html) | disallow irregular whitespace |  | :star: | :star: |
-| [yml/no-multiple-empty-lines](https://ota-meshi.github.io/eslint-plugin-yml/rules/no-multiple-empty-lines.html) | disallow multiple empty lines | :wrench: |  |  |
-| [yml/spaced-comment](https://ota-meshi.github.io/eslint-plugin-yml/rules/spaced-comment.html) | enforce consistent spacing after the `#` in a comment | :wrench: |  | :star: |
+| Rule ID | Description | Fixable | Configurations |
+|:--------|:------------|:-------:|:--------------:|
+| [yml/flow-mapping-curly-newline](https://ota-meshi.github.io/eslint-plugin-yml/rules/flow-mapping-curly-newline.html) | enforce consistent line breaks inside braces | :wrench: | :star2: |
+| [yml/flow-mapping-curly-spacing](https://ota-meshi.github.io/eslint-plugin-yml/rules/flow-mapping-curly-spacing.html) | enforce consistent spacing inside braces | :wrench: | :star2: |
+| [yml/flow-sequence-bracket-newline](https://ota-meshi.github.io/eslint-plugin-yml/rules/flow-sequence-bracket-newline.html) | enforce linebreaks after opening and before closing flow sequence brackets | :wrench: | :star2: |
+| [yml/flow-sequence-bracket-spacing](https://ota-meshi.github.io/eslint-plugin-yml/rules/flow-sequence-bracket-spacing.html) | enforce consistent spacing inside flow sequence brackets | :wrench: | :star2: |
+| [yml/key-spacing](https://ota-meshi.github.io/eslint-plugin-yml/rules/key-spacing.html) | enforce consistent spacing between keys and values in mapping pairs | :wrench: | :star2: |
+| [yml/no-irregular-whitespace](https://ota-meshi.github.io/eslint-plugin-yml/rules/no-irregular-whitespace.html) | disallow irregular whitespace |  | :star: :star2: |
+| [yml/no-multiple-empty-lines](https://ota-meshi.github.io/eslint-plugin-yml/rules/no-multiple-empty-lines.html) | disallow multiple empty lines | :wrench: |  |
+| [yml/spaced-comment](https://ota-meshi.github.io/eslint-plugin-yml/rules/spaced-comment.html) | enforce consistent spacing after the `#` in a comment | :wrench: | :star2: |
 
 <!--RULES_TABLE_END-->
 <!--RULES_SECTION_END-->

--- a/docs/rules/file-extension.md
+++ b/docs/rules/file-extension.md
@@ -10,6 +10,8 @@ since: "v1.2.0"
 
 > enforce YAML file extension
 
+- :gear: This rule is included in `"plugin:yml/stylistic"`.
+
 ## :book: Rule Details
 
 This rule aims to enforce YAML file extension.

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -11,38 +11,44 @@ The rules with the following star :star: are included in the `plugin:yml/recomme
 
 ## YAML Rules
 
-| Rule ID | Description | Fixable | RECOMMENDED | STANDARD |
-|:--------|:------------|:-------:|:-----------:|:--------:|
-| [yml/block-mapping-colon-indicator-newline](./block-mapping-colon-indicator-newline.md) | enforce consistent line breaks after `:` indicator | :wrench: |  |  |
-| [yml/block-mapping-question-indicator-newline](./block-mapping-question-indicator-newline.md) | enforce consistent line breaks after `?` indicator | :wrench: |  | :star: |
-| [yml/block-mapping](./block-mapping.md) | require or disallow block style mappings. | :wrench: |  | :star: |
-| [yml/block-sequence-hyphen-indicator-newline](./block-sequence-hyphen-indicator-newline.md) | enforce consistent line breaks after `-` indicator | :wrench: |  | :star: |
-| [yml/block-sequence](./block-sequence.md) | require or disallow block style sequences. | :wrench: |  | :star: |
-| [yml/file-extension](./file-extension.md) | enforce YAML file extension |  |  |  |
-| [yml/indent](./indent.md) | enforce consistent indentation | :wrench: |  | :star: |
-| [yml/key-name-casing](./key-name-casing.md) | enforce naming convention to key names |  |  |  |
-| [yml/no-empty-document](./no-empty-document.md) | disallow empty document |  | :star: | :star: |
-| [yml/no-empty-key](./no-empty-key.md) | disallow empty mapping keys |  | :star: | :star: |
-| [yml/no-empty-mapping-value](./no-empty-mapping-value.md) | disallow empty mapping values |  | :star: | :star: |
-| [yml/no-empty-sequence-entry](./no-empty-sequence-entry.md) | disallow empty sequence entries |  | :star: | :star: |
-| [yml/no-tab-indent](./no-tab-indent.md) | disallow tabs for indentation. |  | :star: | :star: |
-| [yml/no-trailing-zeros](./no-trailing-zeros.md) | disallow trailing zeros for floats | :wrench: |  |  |
-| [yml/plain-scalar](./plain-scalar.md) | require or disallow plain style scalar. | :wrench: |  | :star: |
-| [yml/quotes](./quotes.md) | enforce the consistent use of either double, or single quotes | :wrench: |  | :star: |
-| [yml/require-string-key](./require-string-key.md) | disallow mapping keys other than strings |  |  |  |
-| [yml/sort-keys](./sort-keys.md) | require mapping keys to be sorted | :wrench: |  |  |
-| [yml/sort-sequence-values](./sort-sequence-values.md) | require sequence values to be sorted | :wrench: |  |  |
-| [yml/vue-custom-block/no-parsing-error](./vue-custom-block/no-parsing-error.md) | disallow parsing errors in Vue custom blocks |  | :star: | :star: |
+Category emojis:
+
+- :star: - recommended
+- :star2: - standard
+- :art: - stylistic
+
+| Rule ID | Description | Fixable | CONFIGS |
+|:--------|:------------|:-------:|:-------:|
+| [yml/block-mapping-colon-indicator-newline](./block-mapping-colon-indicator-newline.md) | enforce consistent line breaks after `:` indicator | :wrench: |  |
+| [yml/block-mapping-question-indicator-newline](./block-mapping-question-indicator-newline.md) | enforce consistent line breaks after `?` indicator | :wrench: | :star2: |
+| [yml/block-mapping](./block-mapping.md) | require or disallow block style mappings. | :wrench: | :star2: |
+| [yml/block-sequence-hyphen-indicator-newline](./block-sequence-hyphen-indicator-newline.md) | enforce consistent line breaks after `-` indicator | :wrench: | :star2: |
+| [yml/block-sequence](./block-sequence.md) | require or disallow block style sequences. | :wrench: | :star2: |
+| [yml/file-extension](./file-extension.md) | enforce YAML file extension |  | :art: |
+| [yml/indent](./indent.md) | enforce consistent indentation | :wrench: | :star2: |
+| [yml/key-name-casing](./key-name-casing.md) | enforce naming convention to key names |  |  |
+| [yml/no-empty-document](./no-empty-document.md) | disallow empty document |  | :star: :star2: |
+| [yml/no-empty-key](./no-empty-key.md) | disallow empty mapping keys |  | :star: :star2: |
+| [yml/no-empty-mapping-value](./no-empty-mapping-value.md) | disallow empty mapping values |  | :star: :star2: |
+| [yml/no-empty-sequence-entry](./no-empty-sequence-entry.md) | disallow empty sequence entries |  | :star: :star2: |
+| [yml/no-tab-indent](./no-tab-indent.md) | disallow tabs for indentation. |  | :star: :star2: |
+| [yml/no-trailing-zeros](./no-trailing-zeros.md) | disallow trailing zeros for floats | :wrench: |  |
+| [yml/plain-scalar](./plain-scalar.md) | require or disallow plain style scalar. | :wrench: | :star2: |
+| [yml/quotes](./quotes.md) | enforce the consistent use of either double, or single quotes | :wrench: | :star2: |
+| [yml/require-string-key](./require-string-key.md) | disallow mapping keys other than strings |  | :art: |
+| [yml/sort-keys](./sort-keys.md) | require mapping keys to be sorted | :wrench: | :art: |
+| [yml/sort-sequence-values](./sort-sequence-values.md) | require sequence values to be sorted | :wrench: | :art: |
+| [yml/vue-custom-block/no-parsing-error](./vue-custom-block/no-parsing-error.md) | disallow parsing errors in Vue custom blocks |  | :star: :star2: |
 
 ## Extension Rules
 
-| Rule ID | Description | Fixable | RECOMMENDED | STANDARD |
-|:--------|:------------|:-------:|:-----------:|:--------:|
-| [yml/flow-mapping-curly-newline](./flow-mapping-curly-newline.md) | enforce consistent line breaks inside braces | :wrench: |  | :star: |
-| [yml/flow-mapping-curly-spacing](./flow-mapping-curly-spacing.md) | enforce consistent spacing inside braces | :wrench: |  | :star: |
-| [yml/flow-sequence-bracket-newline](./flow-sequence-bracket-newline.md) | enforce linebreaks after opening and before closing flow sequence brackets | :wrench: |  | :star: |
-| [yml/flow-sequence-bracket-spacing](./flow-sequence-bracket-spacing.md) | enforce consistent spacing inside flow sequence brackets | :wrench: |  | :star: |
-| [yml/key-spacing](./key-spacing.md) | enforce consistent spacing between keys and values in mapping pairs | :wrench: |  | :star: |
-| [yml/no-irregular-whitespace](./no-irregular-whitespace.md) | disallow irregular whitespace |  | :star: | :star: |
-| [yml/no-multiple-empty-lines](./no-multiple-empty-lines.md) | disallow multiple empty lines | :wrench: |  |  |
-| [yml/spaced-comment](./spaced-comment.md) | enforce consistent spacing after the `#` in a comment | :wrench: |  | :star: |
+| Rule ID | Description | Fixable | CONFIGS |
+|:--------|:------------|:-------:|:-------:|
+| [yml/flow-mapping-curly-newline](./flow-mapping-curly-newline.md) | enforce consistent line breaks inside braces | :wrench: | :star2: |
+| [yml/flow-mapping-curly-spacing](./flow-mapping-curly-spacing.md) | enforce consistent spacing inside braces | :wrench: | :star2: |
+| [yml/flow-sequence-bracket-newline](./flow-sequence-bracket-newline.md) | enforce linebreaks after opening and before closing flow sequence brackets | :wrench: | :star2: |
+| [yml/flow-sequence-bracket-spacing](./flow-sequence-bracket-spacing.md) | enforce consistent spacing inside flow sequence brackets | :wrench: | :star2: |
+| [yml/key-spacing](./key-spacing.md) | enforce consistent spacing between keys and values in mapping pairs | :wrench: | :star2: |
+| [yml/no-irregular-whitespace](./no-irregular-whitespace.md) | disallow irregular whitespace |  | :star: :star2: |
+| [yml/no-multiple-empty-lines](./no-multiple-empty-lines.md) | disallow multiple empty lines | :wrench: |  |
+| [yml/spaced-comment](./spaced-comment.md) | enforce consistent spacing after the `#` in a comment | :wrench: | :star2: |

--- a/docs/rules/require-string-key.md
+++ b/docs/rules/require-string-key.md
@@ -10,6 +10,8 @@ since: "v0.3.0"
 
 > disallow mapping keys other than strings
 
+- :gear: This rule is included in `"plugin:yml/stylistic"`.
+
 ## :book: Rule Details
 
 This rule reports mapping keys defined with an other than a string.

--- a/docs/rules/sort-keys.md
+++ b/docs/rules/sort-keys.md
@@ -10,6 +10,7 @@ since: "v0.3.0"
 
 > require mapping keys to be sorted
 
+- :gear: This rule is included in `"plugin:yml/stylistic"`.
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 ## :book: Rule Details

--- a/docs/rules/sort-sequence-values.md
+++ b/docs/rules/sort-sequence-values.md
@@ -10,6 +10,7 @@ since: "v0.14.0"
 
 > require sequence values to be sorted
 
+- :gear: This rule is included in `"plugin:yml/stylistic"`.
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
 ## :book: Rule Details

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -45,6 +45,7 @@ This plugin provides configs:
 - `*.configs['flat/base']` ... Configuration to enable correct YAML parsing.
 - `*.configs['flat/recommended']` ... Above, plus rules to prevent errors or unintended behavior.
 - `*.configs['flat/standard']` ... Above, plus rules to enforce the common stylistic conventions.
+- `*.configs['flat/stylistic']` ... Rules to enforce additional opinionated stylistic conventions.
 - `*.configs['flat/prettier']` ... Turn off rules that may conflict with [Prettier](https://prettier.io/).
 
 See [the rule list](../rules/index.md) to get the `rules` that this plugin provides.
@@ -74,6 +75,7 @@ This plugin provides configs:
 - `plugin:yml/base` ... Configuration to enable correct YAML parsing.
 - `plugin:yml/recommended` ... Above, plus rules to prevent errors or unintended behavior.
 - `plugin:yml/standard` ... Above, plus rules to enforce the common stylistic conventions.
+- `plugin:yml/stylistic` ... Rules to enforce additional opinionated stylistic conventions.
 - `plugin:yml/prettier` ... Turn off rules that may conflict with [Prettier](https://prettier.io/).
 
 See [the rule list](../rules/index.md) to get the `rules` that this plugin provides.

--- a/src/configs/flat/stylistic.ts
+++ b/src/configs/flat/stylistic.ts
@@ -1,0 +1,23 @@
+// IMPORTANT!
+// This file has been automatically generated,
+// in order to update its content execute "npm run update"
+import type { Linter } from "eslint";
+import base from "./base";
+export default [
+  ...base,
+  {
+    rules: {
+      // eslint-plugin-yml rules
+      "yml/file-extension": "error",
+      "yml/require-string-key": "error",
+      "yml/sort-keys": [
+        "error",
+        { order: { type: "asc" }, pathPattern: "^.*$" },
+      ],
+      "yml/sort-sequence-values": [
+        "error",
+        { order: { type: "asc" }, pathPattern: "^.*$" },
+      ],
+    },
+  },
+] satisfies Linter.FlatConfig[];

--- a/src/configs/stylistic.ts
+++ b/src/configs/stylistic.ts
@@ -1,0 +1,19 @@
+// IMPORTANT!
+// This file has been automatically generated,
+// in order to update its content execute "npm run update"
+import path from "path";
+const base = require.resolve("./base");
+const baseExtend = path.extname(`${base}`) === ".ts" ? "plugin:yml/base" : base;
+export = {
+  extends: [baseExtend],
+  rules: {
+    // eslint-plugin-yml rules
+    "yml/file-extension": "error",
+    "yml/require-string-key": "error",
+    "yml/sort-keys": ["error", { order: { type: "asc" }, pathPattern: "^.*$" }],
+    "yml/sort-sequence-values": [
+      "error",
+      { order: { type: "asc" }, pathPattern: "^.*$" },
+    ],
+  },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,12 @@ import { rules as ruleList } from "./utils/rules";
 import base from "./configs/base";
 import recommended from "./configs/recommended";
 import standard from "./configs/standard";
+import stylistic from "./configs/stylistic";
 import prettier from "./configs/prettier";
 import flatBase from "./configs/flat/base";
 import flatRecommended from "./configs/flat/recommended";
 import flatStandard from "./configs/flat/standard";
+import flatStylistic from "./configs/flat/stylistic";
 import flatPrettier from "./configs/flat/prettier";
 import * as meta from "./meta";
 
@@ -14,10 +16,12 @@ const configs = {
   base,
   recommended,
   standard,
+  stylistic,
   prettier,
   "flat/base": flatBase,
   "flat/recommended": flatRecommended,
   "flat/standard": flatStandard,
+  "flat/stylistic": flatStylistic,
   "flat/prettier": flatPrettier,
 };
 

--- a/src/rules/file-extension.ts
+++ b/src/rules/file-extension.ts
@@ -6,7 +6,7 @@ export default createRule("file-extension", {
   meta: {
     docs: {
       description: "enforce YAML file extension",
-      categories: [],
+      categories: ["stylistic"],
       extensionRule: false,
       layout: false,
     },

--- a/src/rules/require-string-key.ts
+++ b/src/rules/require-string-key.ts
@@ -6,7 +6,7 @@ export default createRule("require-string-key", {
   meta: {
     docs: {
       description: "disallow mapping keys other than strings",
-      categories: null,
+      categories: ["stylistic"],
       extensionRule: false,
       layout: false,
     },
@@ -51,7 +51,7 @@ export default createRule("require-string-key", {
      * Checks if the given node is string
      */
     function isStringNode(
-      node: AST.YAMLContent | AST.YAMLWithMeta | null,
+      node: AST.YAMLContent | AST.YAMLWithMeta | null
     ): boolean {
       if (!node) {
         return false;

--- a/src/rules/sort-keys.ts
+++ b/src/rules/sort-keys.ts
@@ -366,8 +366,12 @@ const ORDER_OBJECT_SCHEMA = {
 export default createRule("sort-keys", {
   meta: {
     docs: {
+      default: [
+        "error",
+        { order: { type: "asc" }, pathPattern: "^.*$" },
+      ],
       description: "require mapping keys to be sorted",
-      categories: null,
+      categories: ["stylistic"],
       extensionRule: false,
       layout: false,
     },

--- a/src/rules/sort-sequence-values.ts
+++ b/src/rules/sort-sequence-values.ts
@@ -386,8 +386,12 @@ const ORDER_OBJECT_SCHEMA = {
 export default createRule("sort-sequence-values", {
   meta: {
     docs: {
+      default: [
+        "error",
+        { order: { type: "asc" }, pathPattern: "^.*$" },
+      ],
       description: "require sequence values to be sorted",
-      categories: null,
+      categories: ["stylistic"],
       extensionRule: false,
       layout: false,
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,7 +36,7 @@ export interface RuleModule {
 export interface RuleMetaData {
   docs: {
     description: string;
-    categories: ("recommended" | "standard")[] | null;
+    categories: ("recommended" | "standard" | "stylistic")[] | null;
     url: string;
     ruleId: string;
     ruleName: string;
@@ -61,9 +61,9 @@ export interface PartialRuleModule {
 export interface PartialRuleMetaData {
   docs: {
     description: string;
-    categories: ("recommended" | "standard")[] | null;
+    categories: ("recommended" | "standard" | "stylistic")[] | null;
     replacedBy?: [];
-    default?: "error" | "warn";
+    default?: "error" | "warn" | ["error" | "warn", unknown];
     extensionRule: string | false;
     layout: boolean;
   };

--- a/tests/src/configs/stylistic.ts
+++ b/tests/src/configs/stylistic.ts
@@ -1,0 +1,77 @@
+import assert from "assert";
+import plugin from "../../../src/index";
+import { LegacyESLint, ESLint } from "../../utils/eslint-compat";
+
+const code = `foo:   42`;
+describe("`stylistic` config", () => {
+  it("legacy `stylistic` config should work. ", async () => {
+    const linter = new LegacyESLint({
+      plugins: {
+        yml: plugin as never,
+      },
+      baseConfig: {
+        parserOptions: {
+          ecmaVersion: 2020,
+        },
+        extends: ["plugin:yml/recommended", "plugin:yml/stylistic"],
+      },
+      useEslintrc: false,
+    });
+    const result = await linter.lintText(code, { filePath: "test.yml" });
+    const messages = result[0].messages;
+
+    assert.deepStrictEqual(
+      messages.map((m) => ({
+        ruleId: m.ruleId,
+        line: m.line,
+        message: m.message,
+      })),
+      [
+        {
+          message: "Expected extension '.yaml' but used extension '.yml'.",
+          ruleId: "yml/file-extension",
+          line: 1,
+        },
+      ]
+    );
+  });
+  it("`flat/stylistic` config should work. ", async () => {
+    const linter = new ESLint({
+      overrideConfigFile: true as never,
+      // @ts-expect-error -- typing bug
+      overrideConfig: [
+        ...(plugin.configs["flat/recommended"] as never),
+        ...(plugin.configs["flat/stylistic"] as never),
+      ],
+    });
+    const result = await linter.lintText(code, { filePath: "test.yml" });
+    const messages = result[0].messages;
+
+    assert.deepStrictEqual(
+      messages.map((m) => ({
+        ruleId: m.ruleId,
+        line: m.line,
+        message: m.message,
+      })),
+      [
+        {
+          message: "Expected extension '.yaml' but used extension '.yml'.",
+          ruleId: "yml/file-extension",
+          line: 1,
+        },
+      ]
+    );
+
+    const resultWithJs = await linter.lintText(";", { filePath: "test.js" });
+    const messagesWithJs = resultWithJs[0].messages;
+
+    assert.deepStrictEqual(
+      messagesWithJs.map((m) => ({
+        ruleId: m.ruleId,
+        line: m.line,
+        message: m.message,
+      })),
+      []
+    );
+  });
+});

--- a/tools/render-rules.ts
+++ b/tools/render-rules.ts
@@ -1,6 +1,12 @@
 import type { RuleModule } from "../src/types";
 import { rules } from "../src/utils/rules";
 
+const categoryEmojis = {
+  recommended: ":star:",
+  standard: ":star2:",
+  stylistic: ":art:",
+};
+
 //eslint-disable-next-line jsdoc/require-jsdoc -- tool
 export default function renderRulesTableContent(
   categoryLevel: number,
@@ -20,22 +26,15 @@ export default function renderRulesTableContent(
   //eslint-disable-next-line jsdoc/require-jsdoc -- tool
   function toRuleRow(rule: RuleModule) {
     const fixableMark = rule.meta.fixable ? ":wrench:" : "";
-    const recommendedMark =
-      rule.meta.docs.categories &&
-      rule.meta.docs.categories.includes("recommended")
-        ? ":star:"
-        : "";
-    const standardMark =
-      rule.meta.docs.categories &&
-      rule.meta.docs.categories.includes("standard")
-        ? ":star:"
-        : "";
+    const categoriesMark = rule.meta.docs.categories
+      ? rule.meta.docs.categories.map(category => categoryEmojis[category]).join(" ")
+      : "";
     const link = `[${rule.meta.docs.ruleId}](${buildRulePath(
-      rule.meta.docs.ruleName || "",
+      rule.meta.docs.ruleName || ""
     )})`;
     const description = rule.meta.docs.description || "(no description)";
 
-    return `| ${link} | ${description} | ${fixableMark} | ${recommendedMark} | ${standardMark} |`;
+    return `| ${link} | ${description} | ${fixableMark} | ${categoriesMark} |`;
   }
 
   //eslint-disable-next-line jsdoc/require-jsdoc -- tool
@@ -55,14 +54,18 @@ export default function renderRulesTableContent(
   let rulesTableContent = `
 #${"#".repeat(categoryLevel)} YAML Rules
 
-| Rule ID | Description | Fixable | RECOMMENDED | STANDARD |
-|:--------|:------------|:-------:|:-----------:|:--------:|
+Category emojis:
+
+${Object.entries(categoryEmojis).map(([category, emoji]) => `- ${emoji} - ${category}`).join("\n")}
+
+| Rule ID | Description | Fixable | Configurations |
+|:--------|:------------|:-------:|:--------------:|
 ${pluginRules.map(toRuleRow).join("\n")}
 
 #${"#".repeat(categoryLevel)} Extension Rules
 
-| Rule ID | Description | Fixable | RECOMMENDED | STANDARD |
-|:--------|:------------|:-------:|:-----------:|:--------:|
+| Rule ID | Description | Fixable | Configurations |
+|:--------|:------------|:-------:|:--------------:|
 ${extensionRules.map(toRuleRow).join("\n")}
 `;
 

--- a/tools/update-rulesets.ts
+++ b/tools/update-rulesets.ts
@@ -33,6 +33,19 @@ const CONFIGS = {
     },
     config: "standard",
   },
+  stylistic: {
+    filter(rule: RuleModule) {
+      return (
+        rule.meta.docs.categories &&
+        !rule.meta.deprecated &&
+        rule.meta.docs.categories.includes("stylistic")
+      );
+    },
+    option(rule: RuleModule) {
+      return rule.meta.docs.default || "error";
+    },
+    config: "stylistic",
+  },
   prettier: {
     filter(rule: RuleModule) {
       return rule.meta.docs.layout;
@@ -44,7 +57,12 @@ const CONFIGS = {
   },
 };
 
-for (const rec of ["recommended", "standard", "prettier"] as const) {
+for (const rec of [
+  "recommended",
+  "standard",
+  "stylistic",
+  "prettier",
+] as const) {
   let content = `/*
  * IMPORTANT!
  * This file has been automatically generated,
@@ -61,7 +79,7 @@ export = {
         ${rules
           .filter(CONFIGS[rec].filter)
           .map((rule) => {
-            return `"${rule.meta.docs.ruleId}": "${CONFIGS[rec].option(rule)}"`;
+            return `"${rule.meta.docs.ruleId}": ${JSON.stringify(CONFIGS[rec].option(rule))}`;
           })
           .join(",\n")}
     },
@@ -84,7 +102,12 @@ export = {
   fs.writeFileSync(filePath, content);
 }
 
-for (const rec of ["recommended", "standard", "prettier"] as const) {
+for (const rec of [
+  "recommended",
+  "standard",
+  "stylistic",
+  "prettier",
+] as const) {
   let content = `/*
  * IMPORTANT!
  * This file has been automatically generated,
@@ -100,7 +123,7 @@ export default [
         ${rules
           .filter(CONFIGS[rec].filter)
           .map((rule) => {
-            return `"${rule.meta.docs.ruleId}": "${CONFIGS[rec].option(rule)}"`;
+            return `"${rule.meta.docs.ruleId}": ${JSON.stringify(CONFIGS[rec].option(rule))}`;
           })
           .join(",\n")}
     },


### PR DESCRIPTION
Fixes #422.

Adds a new `stylistic` config as a sibling to `recommended`, `standard`, etc.

It includes the following rules mentioned in #422:

* [`yml/file-extension`](https://ota-meshi.github.io/eslint-plugin-yml/rules/yml/file-extension): with the default (preferring `.yaml`), as that's the YAML spec recommendation
* [`yml/require-string-key`](https://ota-meshi.github.io/eslint-plugin-yml/rules/yml/require-string-key): I've never seen a non-string key in real-world usage
* [`yml/sort-keys`](https://ota-meshi.github.io/eslint-plugin-yml/rules/yml/sort-keys): configured to sort all paths ascending, for comprehensive sorting
* [`yml/sort-sequence-values`](https://ota-meshi.github.io/eslint-plugin-yml/rules/yml/sort-sequence-values): configured to sort all paths ascending, for comprehensive sorting

It does not include the following rules also mentioned in #422:

* [`yml/key-name-casing`](https://ota-meshi.github.io/eslint-plugin-yml/rules/yml/key-name-casing): as many configs have to contend with naming requirements outside the repo (GitHub Actions, services configs, etc.)
* [`yml/no-trailing-zeros`](https://ota-meshi.github.io/eslint-plugin-yml/rules/yml/no-trailing-zeros.html): as it's already disabled in the `prettier` config

Additionally tweaks the README.md tables to have a single column including emojis for included configs. This is a more visually compact change from the current strategy of one column per two configs. I think it'd scale well for #423, too. 