### PR TITLE
Add yml/no-trailing-spaces

### DIFF
--- a/.changeset/real-dots-agree.md
+++ b/.changeset/real-dots-agree.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-yml": minor
+---
+
+Add `yml/no-trailing-spaces` rule

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ The rules with the following star :star: are included in the config.
 | [yml/key-spacing](https://ota-meshi.github.io/eslint-plugin-yml/rules/key-spacing.html) | enforce consistent spacing between keys and values in mapping pairs | :wrench: |  | :star: |
 | [yml/no-irregular-whitespace](https://ota-meshi.github.io/eslint-plugin-yml/rules/no-irregular-whitespace.html) | disallow irregular whitespace |  | :star: | :star: |
 | [yml/no-multiple-empty-lines](https://ota-meshi.github.io/eslint-plugin-yml/rules/no-multiple-empty-lines.html) | disallow multiple empty lines | :wrench: |  | :star: |
+| [yml/no-trailing-spaces](https://ota-meshi.github.io/eslint-plugin-yml/rules/no-trailing-spaces.html) | disallow trailing whitespace at the end of lines | :wrench: |  | :star: |
 | [yml/spaced-comment](https://ota-meshi.github.io/eslint-plugin-yml/rules/spaced-comment.html) | enforce consistent spacing after the `#` in a comment | :wrench: |  | :star: |
 
 <!--RULES_TABLE_END-->

--- a/docs/rules/block-mapping-colon-indicator-newline.md
+++ b/docs/rules/block-mapping-colon-indicator-newline.md
@@ -41,7 +41,7 @@ This rule aims to enforce consistent line breaks after `:` indicator.
 ```yaml
 yml/block-mapping-colon-indicator-newline:
   - error
-  - never # or "always" 
+  - never # or "always"
 ```
 
 - `"always"` ... Requires line breaks after after `:` indicator of block style mappings.

--- a/docs/rules/block-mapping-question-indicator-newline.md
+++ b/docs/rules/block-mapping-question-indicator-newline.md
@@ -43,7 +43,7 @@ This rule aims to enforce consistent line breaks after `?` indicator.
 ```yaml
 yml/block-mapping-question-indicator-newline:
   - error
-  - never # or "always" 
+  - never # or "always"
 ```
 
 - `"always"` ... Requires line breaks after after `?` indicator of block style mappings.

--- a/docs/rules/block-sequence-hyphen-indicator-newline.md
+++ b/docs/rules/block-sequence-hyphen-indicator-newline.md
@@ -39,7 +39,7 @@ This rule aims to enforce consistent line breaks after `-` indicator.
 ```yaml
 yml/block-sequence-hyphen-indicator-newline:
   - error
-  - never # or "always" 
+  - never # or "always"
   - nestedHyphen: always # or "never"
   - blockMapping: never # or "always"
 ```

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -45,4 +45,5 @@ The rules with the following star :star: are included in `configs.recommended` o
 | [yml/key-spacing](./key-spacing.md) | enforce consistent spacing between keys and values in mapping pairs | :wrench: |  | :star: |
 | [yml/no-irregular-whitespace](./no-irregular-whitespace.md) | disallow irregular whitespace |  | :star: | :star: |
 | [yml/no-multiple-empty-lines](./no-multiple-empty-lines.md) | disallow multiple empty lines | :wrench: |  | :star: |
+| [yml/no-trailing-spaces](./no-trailing-spaces.md) | disallow trailing whitespace at the end of lines | :wrench: |  | :star: |
 | [yml/spaced-comment](./spaced-comment.md) | enforce consistent spacing after the `#` in a comment | :wrench: |  | :star: |

--- a/docs/rules/no-trailing-spaces.md
+++ b/docs/rules/no-trailing-spaces.md
@@ -1,0 +1,67 @@
+---
+pageClass: "rule-details"
+sidebarDepth: 0
+title: "yml/no-trailing-spaces"
+description: "disallow trailing whitespace at the end of lines"
+since: "v3.5.0"
+---
+
+# yml/no-trailing-spaces
+
+> disallow trailing whitespace at the end of lines
+
+- :gear: This rule is included in `configs.standard`.
+- :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
+
+## :book: Rule Details
+
+This rule disallows trailing whitespace at the end of lines.
+
+<eslint-code-block fix>
+
+<!-- eslint-skip -->
+
+```yaml
+# eslint yml/no-trailing-spaces: 'error'
+
+# ✓ GOOD
+"GOOD": "foo"
+
+# ✗ BAD
+"BAD": "bar"
+#         ^ trailing whitespace at the end of the previous line
+```
+
+</eslint-code-block>
+
+## :wrench: Options
+
+```yaml
+yml/no-trailing-spaces:
+  - error
+  - skipBlankLines: false
+    ignoreComments: false
+```
+
+- `skipBlankLines` ... Ignores whitespace-only lines. Default is `false`.
+- `ignoreComments` ... Ignores trailing whitespace in YAML comments. Default is `false`.
+
+Same as [no-trailing-spaces] rule option. See [here](https://eslint.org/docs/rules/no-trailing-spaces#options) for details.
+
+## :couple: Related rules
+
+- [no-trailing-spaces]
+
+[no-trailing-spaces]: https://eslint.org/docs/rules/no-trailing-spaces
+
+## :rocket: Version
+
+This rule was introduced in eslint-plugin-yml v3.5.0
+
+## :mag: Implementation
+
+- [Rule source](https://github.com/ota-meshi/eslint-plugin-yml/blob/master/src/rules/no-trailing-spaces.ts)
+- [Test source](https://github.com/ota-meshi/eslint-plugin-yml/blob/master/tests/src/rules/no-trailing-spaces.ts)
+- [Test fixture sources](https://github.com/ota-meshi/eslint-plugin-yml/tree/master/tests/fixtures/rules/no-trailing-spaces)
+
+<sup>Taken with ❤️ [from ESLint core](https://eslint.org/docs/rules/no-trailing-spaces)</sup>

--- a/docs/rules/no-trailing-spaces.md
+++ b/docs/rules/no-trailing-spaces.md
@@ -3,13 +3,13 @@ pageClass: "rule-details"
 sidebarDepth: 0
 title: "yml/no-trailing-spaces"
 description: "disallow trailing whitespace at the end of lines"
-since: "v3.5.0"
 ---
 
 # yml/no-trailing-spaces
 
 > disallow trailing whitespace at the end of lines
 
+- :exclamation: <badge text="This rule has not been released yet." vertical="middle" type="error"> **_This rule has not been released yet._** </badge>
 - :gear: This rule is included in `configs.standard`.
 - :wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
@@ -53,10 +53,6 @@ Same as [no-trailing-spaces] rule option. See [here](https://eslint.org/docs/rul
 - [no-trailing-spaces]
 
 [no-trailing-spaces]: https://eslint.org/docs/rules/no-trailing-spaces
-
-## :rocket: Version
-
-This rule was introduced in eslint-plugin-yml v3.5.0
 
 ## :mag: Implementation
 

--- a/docs/rules/sort-keys.md
+++ b/docs/rules/sort-keys.md
@@ -45,7 +45,7 @@ yml/sort-keys:
   - error
   # For example, a definition for eslintrc
   - pathPattern: ^$ # Hits the root properties
-    order: 
+    order:
       - root
       - plugins
       - extends

--- a/src/configs/flat/prettier.ts
+++ b/src/configs/flat/prettier.ts
@@ -18,6 +18,7 @@ export default [
       "yml/indent": "off",
       "yml/key-spacing": "off",
       "yml/no-multiple-empty-lines": "off",
+      "yml/no-trailing-spaces": "off",
       "yml/no-trailing-zeros": "off",
       "yml/quotes": "off",
     },

--- a/src/configs/flat/standard.ts
+++ b/src/configs/flat/standard.ts
@@ -26,6 +26,7 @@ export default [
       "yml/no-irregular-whitespace": "error",
       "yml/no-multiple-empty-lines": "error",
       "yml/no-tab-indent": "error",
+      "yml/no-trailing-spaces": "error",
       "yml/no-trailing-zeros": "error",
       "yml/plain-scalar": "error",
       "yml/quotes": "error",

--- a/src/rules/no-trailing-spaces.ts
+++ b/src/rules/no-trailing-spaces.ts
@@ -1,0 +1,137 @@
+import type { AST } from "yaml-eslint-parser";
+import { createRule } from "../utils/index.js";
+
+const BLANK_CLASS =
+  "[\\t \\u00a0\\u2000\\u2001\\u2002\\u2003\\u2004\\u2005\\u2006\\u2007\\u2008\\u2009\\u200a\\u200b\\u3000]";
+const TRAILING_SPACES = new RegExp(`${BLANK_CLASS}+$`, "u");
+const BLANK_LINE = new RegExp(`^${BLANK_CLASS}*$`, "u");
+
+type SourceRange = [number, number];
+
+/** Check whether a reported whitespace range is fully inside a known range. */
+function isInRange(rangeStart: number, rangeEnd: number, range: SourceRange) {
+  return range[0] <= rangeStart && rangeEnd <= range[1];
+}
+
+export default createRule("no-trailing-spaces", {
+  meta: {
+    docs: {
+      description: "disallow trailing whitespace at the end of lines",
+      categories: ["standard"],
+      extensionRule: "no-trailing-spaces",
+      layout: true,
+    },
+    fixable: "whitespace",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          skipBlankLines: {
+            type: "boolean",
+            default: false,
+          },
+          ignoreComments: {
+            type: "boolean",
+            default: false,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      trailingSpace: "Trailing spaces not allowed.",
+    },
+    type: "layout",
+  },
+  create(context) {
+    const sourceCode = context.sourceCode;
+    if (!sourceCode.parserServices?.isYAML) {
+      return {};
+    }
+
+    const options = context.options[0] || {};
+    const skipBlankLines = Boolean(options.skipBlankLines);
+    const ignoreComments = Boolean(options.ignoreComments);
+    const scalarRanges: {
+      range: SourceRange;
+      startLine: number;
+    }[] = [];
+
+    /** Check ranges that should not be reported or fixed. */
+    function isIgnoredRange(
+      lineNumber: number,
+      rangeStart: number,
+      rangeEnd: number,
+    ) {
+      if (
+        ignoreComments &&
+        sourceCode
+          .getAllComments()
+          .some((comment) => isInRange(rangeStart, rangeEnd, comment.range))
+      ) {
+        return true;
+      }
+
+      return scalarRanges.some(
+        (scalar) =>
+          lineNumber > scalar.startLine &&
+          isInRange(rangeStart, rangeEnd, scalar.range),
+      );
+    }
+
+    return {
+      YAMLScalar(node: AST.YAMLScalar) {
+        if (node.loc.start.line < node.loc.end.line) {
+          scalarRanges.push({
+            range: node.range,
+            startLine: node.loc.start.line,
+          });
+        }
+      },
+      "Program:exit"() {
+        for (
+          let lineIndex = 0;
+          lineIndex < sourceCode.lines.length;
+          lineIndex++
+        ) {
+          const line = sourceCode.lines[lineIndex];
+          const match = TRAILING_SPACES.exec(line);
+          if (!match) {
+            continue;
+          }
+
+          if (skipBlankLines && BLANK_LINE.test(line)) {
+            continue;
+          }
+
+          const lineNumber = lineIndex + 1;
+          const startColumn = match.index;
+          const endColumn = line.length;
+          const rangeStart = sourceCode.getIndexFromLoc({
+            line: lineNumber,
+            column: startColumn,
+          });
+          const rangeEnd = sourceCode.getIndexFromLoc({
+            line: lineNumber,
+            column: endColumn,
+          });
+
+          if (isIgnoredRange(lineNumber, rangeStart, rangeEnd)) {
+            continue;
+          }
+
+          context.report({
+            loc: {
+              start: { line: lineNumber, column: startColumn },
+              end: { line: lineNumber, column: endColumn },
+            },
+            messageId: "trailingSpace",
+            fix(fixer) {
+              return fixer.removeRange([rangeStart, rangeEnd]);
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/src/utils/rules.ts
+++ b/src/utils/rules.ts
@@ -22,6 +22,7 @@ import noEmptySequenceEntry from "../rules/no-empty-sequence-entry.ts";
 import noIrregularWhitespace from "../rules/no-irregular-whitespace.ts";
 import noMultipleEmptyLines from "../rules/no-multiple-empty-lines.ts";
 import noTabIndent from "../rules/no-tab-indent.ts";
+import noTrailingSpaces from "../rules/no-trailing-spaces.ts";
 import noTrailingZeros from "../rules/no-trailing-zeros.ts";
 import plainScalar from "../rules/plain-scalar.ts";
 import quotes from "../rules/quotes.ts";
@@ -52,6 +53,7 @@ export const rules = [
   noIrregularWhitespace,
   noMultipleEmptyLines,
   noTabIndent,
+  noTrailingSpaces,
   noTrailingZeros,
   plainScalar,
   quotes,

--- a/tests/fixtures/rules/no-trailing-spaces/invalid/_placeholder
+++ b/tests/fixtures/rules/no-trailing-spaces/invalid/_placeholder
@@ -1,0 +1,1 @@
+Inline tests cover invalid cases with escaped trailing whitespace.

--- a/tests/fixtures/rules/no-trailing-spaces/valid/default-input.yml
+++ b/tests/fixtures/rules/no-trailing-spaces/valid/default-input.yml
@@ -1,0 +1,3 @@
+# {}
+key: value
+# comment

--- a/tests/src/rules/no-trailing-spaces.ts
+++ b/tests/src/rules/no-trailing-spaces.ts
@@ -1,0 +1,106 @@
+import { RuleTester } from "eslint";
+import rule from "../../../src/rules/no-trailing-spaces.ts";
+import { loadTestCases } from "../../utils/utils.ts";
+import plugin from "../../../src/index.ts";
+
+const tester = new RuleTester({
+  plugins: { yml: plugin },
+  language: "yml/yaml",
+});
+const trailingSpaces = "   ";
+const trailingTabAndSpace = "\t ";
+
+const error = {
+  message: "Trailing spaces not allowed.",
+};
+
+tester.run(
+  "no-trailing-spaces",
+  rule,
+  loadTestCases(
+    "no-trailing-spaces",
+    {},
+    {
+      valid: [
+        {
+          code: `# comment${trailingSpaces}
+key: value
+inline: value # comment${trailingTabAndSpace}
+`,
+          options: [{ ignoreComments: true }],
+        },
+        {
+          code: `key: value
+${trailingSpaces}
+next: value
+`,
+          options: [{ skipBlankLines: true }],
+        },
+        {
+          code: `block: |
+  keep${trailingSpaces}
+  value
+`,
+        },
+      ],
+      invalid: [
+        {
+          code: `# comment${trailingSpaces}
+key: value${trailingSpaces}
+`,
+          output: `# comment
+key: value
+`,
+          errors: [
+            {
+              ...error,
+              line: 1,
+              column: 10,
+            },
+            {
+              ...error,
+              line: 2,
+              column: 11,
+            },
+          ],
+        },
+        {
+          code: `# comment${trailingSpaces}
+key: value${trailingSpaces}
+inline: value # comment${trailingSpaces}
+`,
+          output: `# comment${trailingSpaces}
+key: value
+inline: value # comment${trailingSpaces}
+`,
+          options: [{ ignoreComments: true }],
+          errors: [
+            {
+              ...error,
+              line: 2,
+              column: 11,
+            },
+          ],
+        },
+        {
+          code: `key: value
+${trailingSpaces}
+next: value${trailingSpaces}
+`,
+          output: `key: value
+${trailingSpaces}
+next: value
+`,
+          options: [{ skipBlankLines: true }],
+          errors: [
+            {
+              ...error,
+              line: 3,
+              column: 12,
+            },
+          ],
+        },
+      ],
+    },
+  ),
+);


### PR DESCRIPTION
This adds a YAML-aware `yml/no-trailing-spaces` rule with support for comments, blank lines, and safe whitespace fixes.
The rule supports `ignoreComments` and `skipBlankLines`, and it leaves multiline scalar content alone. I checked the focused cases with 10 passing, the full suite with 5,601 passing, lint, build, and `git diff --check`.
Fixes #277
