### PR TITLE
fix(sort-keys): don't duplicate inline comments when reordering block sequence keys

### DIFF
--- a/.changeset/sort-keys-preserve-comments.md
+++ b/.changeset/sort-keys-preserve-comments.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-yml": patch
+---
+
+fix(sort-keys): don't duplicate inline comments when reordering block sequence keys

--- a/src/rules/sort-keys.ts
+++ b/src/rules/sort-keys.ts
@@ -951,11 +951,13 @@ export default createRule("sort-keys", {
 
         const nextToken = sourceCode.getTokenAfter(data.node, {
           includeComments: true,
+          filter: (t) =>
+            !isCommentToken(t) || data.node.loc.end.line < t.loc.start.line,
         })!;
-        // | - a: 1
+        // | - a: 1 # comment
         //     ^ data.node.range[0]
         // |   b: 2
-        //     ^ nextToken
+        //     ^ nextToken (comments on the node's own line move with it)
         const removeRange: AST.Range = [data.node.range[0], nextToken.range[0]];
         yield fixer.removeRange(removeRange);
 
@@ -1076,6 +1078,8 @@ export default createRule("sort-keys", {
       if (beforeToken) {
         const next = sourceCode.getTokenAfter(beforeToken, {
           includeComments: true,
+          filter: (t) =>
+            !isCommentToken(t) || beforeToken.loc.end.line < t.loc.start.line,
         })!;
         if (
           beforeToken.loc.end.line < next.loc.start.line ||

--- a/tests/src/rules/sort-keys.ts
+++ b/tests/src/rules/sort-keys.ts
@@ -255,6 +255,42 @@ tester.run(
           language: "yml/yaml",
         },
 
+        // inline comment moves with its key, no duplication
+        {
+          code: `- b: 1 # comment
+  a: 2
+`,
+          output: `- a: 2
+  b: 1 # comment
+`,
+          options: [{ order: { type: "asc" }, pathPattern: ".*" }],
+          errors: [
+            "Expected mapping keys to be in ascending order. 'b' should be after 'a'.",
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+
+        // inline comment on the pair above the moved key is not duplicated
+        {
+          code: `- b: 1
+  c: 2 # comment
+  a: 3
+`,
+          output: `- a: 3
+  b: 1
+  c: 2 # comment
+`,
+          options: [{ order: { type: "asc" }, pathPattern: ".*" }],
+          errors: [
+            "Expected mapping keys to be in ascending order. 'a' should be before 'b'.",
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+
         // Other
         {
           code: `


### PR DESCRIPTION
When `yml/sort-keys` reorders keys inside a block sequence entry, an inline comment was duplicated (left in place and also copied with the moved key), and an inline comment on the pair above the moved key corrupted the fix's indent calculation, mangling the output.

As suggested in review, this is now fixed by adjusting the token ranges used by `fixToMoveDownForBlock` / `fixToMoveUpForBlock` (skipping comments on the pair's own line when locating the following token), with no changes to blank-line or own-line comment handling.

### Inline comment duplication

```yaml
# input

- uses: actions/checkout@v4 # pin
  name: Checkout
```

```yaml
# autofix before  →  `# pin` duplicated

- # pin
  name: Checkout
  uses: actions/checkout@v4 # pin
```

```yaml
# autofix now

- name: Checkout
  uses: actions/checkout@v4 # pin
```

### Inline comment on the pair above the moved key

```yaml
# input

- b: 1
  c: 2 # comment
  a: 3
```

```yaml
# autofix before  →  output mangled

-
  a: 3 b: 1
  c: 2 # comment
```

```yaml
# autofix now

- a: 3
  b: 1
  c: 2 # comment
```