### PR TITLE
test: fix tests failing on windows machine

### DIFF
--- a/tests/utils/utils.ts
+++ b/tests/utils/utils.ts
@@ -222,7 +222,7 @@ export function makeSuiteTests(
         `yaml-test-suite-for-${optionName}/`,
       );
       const inputFile = path.join(fixtureDir, path.basename(fixture));
-      const filename = inputFile.slice(inputFile.indexOf(ruleName));
+      const filename = toRuleRelativeName(inputFile, ruleName);
       const code = `# ${filename}\n${code0}`;
 
       const result = verify(
@@ -385,7 +385,7 @@ function getConfig(ruleName: string, inputFile: string) {
       : {},
   );
 
-  const filename = inputFile.slice(inputFile.indexOf(ruleName));
+  const filename = toRuleRelativeName(inputFile, ruleName);
 
   const code0 = fs.readFileSync(inputFile, "utf8");
   const overrideConfigFile: string = inputFile.replace(
@@ -434,6 +434,11 @@ function getConfig(ruleName: string, inputFile: string) {
   }
 
   return Object.assign(baseConfig, config, { code, filename });
+}
+
+function toRuleRelativeName(inputFile: string, ruleName: string) {
+  const posixInputFile = inputFile.replace(/\\/gu, "/");
+  return posixInputFile.slice(posixInputFile.indexOf(ruleName));
 }
 
 function isYaml(fileName: string) {


### PR DESCRIPTION
2429 failures on windows due to errors such as:

```
      AssertionError [ERR_ASSERTION]: Output is incorrect.
actual expected

'#spaced-comment\\/invalid\\/never01-input.yml\n#a\n#b\n#c'

      + expected - actual

      -#spaced-comment\invalid\never01-input.yml
      +#spaced-comment/invalid/never01-input.yml
       #a
       #b
       #c
      
```

With this change, there is `5601 passing (4s)`