### PR TITLE
fix: keep non-Prettier YAML rules enabled

### DIFF
--- a/src/configs/flat/prettier.ts
+++ b/src/configs/flat/prettier.ts
@@ -9,7 +9,6 @@ export default [
     rules: {
       // eslint-plugin-yml rules
       "yml/block-mapping-colon-indicator-newline": "off",
-      "yml/block-mapping-question-indicator-newline": "off",
       "yml/block-sequence-hyphen-indicator-newline": "off",
       "yml/flow-mapping-curly-newline": "off",
       "yml/flow-mapping-curly-spacing": "off",
@@ -19,7 +18,6 @@ export default [
       "yml/key-spacing": "off",
       "yml/no-multiple-empty-lines": "off",
       "yml/no-trailing-spaces": "off",
-      "yml/no-trailing-zeros": "off",
       "yml/quotes": "off",
     },
   },

--- a/src/rules/block-mapping-question-indicator-newline.ts
+++ b/src/rules/block-mapping-question-indicator-newline.ts
@@ -7,7 +7,7 @@ export default createRule("block-mapping-question-indicator-newline", {
       description: "enforce consistent line breaks after `?` indicator",
       categories: ["standard"],
       extensionRule: false,
-      layout: true,
+      layout: false,
     },
     fixable: "whitespace",
     schema: [

--- a/src/rules/no-trailing-zeros.ts
+++ b/src/rules/no-trailing-zeros.ts
@@ -7,7 +7,7 @@ export default createRule("no-trailing-zeros", {
       description: "disallow trailing zeros for floats",
       categories: ["standard"],
       extensionRule: false,
-      layout: true,
+      layout: false,
     },
     fixable: "code",
     schema: [],


### PR DESCRIPTION
## Summary

- mark `yml/block-mapping-question-indicator-newline` as non-layout so it stays enabled in the Prettier preset
- mark `yml/no-trailing-zeros` as non-layout for the same reason
- regenerate the flat Prettier preset to remove both rules from its disabled list

This follows the maintainer guidance in #636. The colon-indicator rule remains disabled because it conflicts with Prettier when configured with `always`.

## Validation

- `npm run build` passes
- the focused rule test command runs, with existing Windows CRLF fixture mismatches in the repository suite
- `git diff --check` passes

The repository's `npm run update` wrapper currently fails on Windows with tsx's `ERR_UNSUPPORTED_ESM_URL_SCHEME`, so the generated config was updated to the exact output implied by the two metadata changes.