### PR TITLE
Add ignore order option to yml/sort-keys

### DIFF
--- a/.changeset/tidy-keys-rest.md
+++ b/.changeset/tidy-keys-rest.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-yml": minor
+---
+
+Add an `ignore` order type to `yml/sort-keys` path options.

--- a/docs/rules/sort-keys.md
+++ b/docs/rules/sort-keys.md
@@ -73,16 +73,31 @@ The option receives multiple objects with the following properties:
         - `type`:
           - `"asc"` ... Enforce properties to be in ascending order. This is default.
           - `"desc"` ... Enforce properties to be in descending order.
+          - `"ignore"` ... Do not enforce an order for properties matching `keyPattern`.
         - `caseSensitive` ... If `true`, enforce properties to be in case-sensitive order. Default is `true`.
         - `natural` ... If `true`, enforce properties to be in natural order. Default is `false`.
   - Object ... The object has the following properties:
     - `type`:
       - `"asc"` ... Enforce properties to be in ascending order. This is default.
       - `"desc"` ... Enforce properties to be in descending order.
+      - `"ignore"` ... Do not enforce an order for properties at matching paths.
     - `caseSensitive` ... If `true`, enforce properties to be in case-sensitive order. Default is `true`.
     - `natural` ... If `true`, enforce properties to be in natural order. Default is `false`.
 - `minKeys` ... Specifies the minimum number of keys that an object should have in order for the object's unsorted keys to produce an error. Default is `2`, which means by default all objects with unsorted keys will result in lint errors.
 - `allowLineSeparatedGroups` ... If `true`, the rule allows to group object keys through line breaks. In other words, a blank line after a property will reset the sorting of keys. Default is `false`.
+
+Use `{ type: ignore }` before a fallback option to preserve the existing
+property order at specific paths. For example, package export condition order
+can affect module resolution:
+
+```yaml
+yml/sort-keys:
+  - error
+  - pathPattern: '^exports\["\."\]$'
+    order: { type: ignore }
+  - pathPattern: .*
+    order: { type: asc }
+```
 
 You can also define options in the same format as the [sort-keys] rule.
 

--- a/src/rules/sort-keys.ts
+++ b/src/rules/sort-keys.ts
@@ -1,4 +1,5 @@
 import naturalCompare from "natural-compare";
+import type { JSONSchema4 } from "json-schema";
 import type { AST } from "yaml-eslint-parser";
 import { createRule } from "../utils/index.js";
 import { isComma, isCommentToken } from "../utils/ast-utils.js";
@@ -30,11 +31,12 @@ type PatternOption = {
   hasProperties: string[];
   order:
     | OrderObject
+    | IgnoreOrderObject
     | (
         | string
         | {
             keyPattern?: string;
-            order?: OrderObject;
+            order?: OrderObject | IgnoreOrderObject;
           }
       )[];
   minKeys?: number;
@@ -44,6 +46,9 @@ type OrderObject = {
   type?: OrderTypeOption;
   caseSensitive?: boolean;
   natural?: boolean;
+};
+type IgnoreOrderObject = {
+  type: "ignore";
 };
 type ParsedOption = {
   isTargetMapping: (node: YAMLMappingData) => boolean;
@@ -233,6 +238,25 @@ function buildValidatorFromType(
 }
 
 /**
+ * Parse an order option for a key pattern.
+ */
+function parseNestedOrder(order?: OrderObject | IgnoreOrderObject) {
+  if (order?.type === "ignore") {
+    return {
+      ignore: true,
+      isValidNestOrder: () => true,
+    };
+  }
+  const type: OrderTypeOption = order?.type ?? "asc";
+  const insensitive = order?.caseSensitive === false;
+  const natural = Boolean(order?.natural);
+  return {
+    ignore: false,
+    isValidNestOrder: buildValidatorFromType(type, insensitive, natural),
+  };
+}
+
+/**
  * Parse options
  */
 function parseOptions(
@@ -266,6 +290,15 @@ function parseOptions(
     const minKeys: number = opt.minKeys ?? 2;
     const allowLineSeparatedGroups = opt.allowLineSeparatedGroups || false;
     if (!Array.isArray(order)) {
+      if (order.type === "ignore") {
+        return {
+          isTargetMapping,
+          ignore: () => true,
+          isValidOrder: () => true,
+          orderText: "ignored",
+          allowLineSeparatedGroups,
+        };
+      }
       const type: OrderTypeOption = order.type ?? "asc";
       const insensitive = order.caseSensitive === false;
       const natural = Boolean(order.natural);
@@ -282,29 +315,30 @@ function parseOptions(
     }
     const parsedOrder: {
       test: (data: YAMLPairData) => boolean;
+      ignore: boolean;
       isValidNestOrder: Validator;
     }[] = [];
     for (const o of order) {
       if (typeof o === "string") {
         parsedOrder.push({
           test: (data) => data.name === o,
+          ignore: false,
           isValidNestOrder: () => true,
         });
       } else {
         const keyPattern = o.keyPattern ? new RegExp(o.keyPattern) : null;
-        const nestOrder = o.order ?? {};
-        const type: OrderTypeOption = nestOrder.type ?? "asc";
-        const insensitive = nestOrder.caseSensitive === false;
-        const natural = Boolean(nestOrder.natural);
         parsedOrder.push({
           test: (data) => (keyPattern ? keyPattern.test(data.name) : true),
-          isValidNestOrder: buildValidatorFromType(type, insensitive, natural),
+          ...parseNestedOrder(o.order),
         });
       }
     }
     return {
       isTargetMapping,
-      ignore: (data) => parsedOrder.every((p) => !p.test(data)),
+      ignore: (data) => {
+        const order = parsedOrder.find((p) => p.test(data));
+        return !order || order.ignore;
+      },
       isValidOrder(a, b) {
         for (const p of parsedOrder) {
           const matchA = p.test(a);
@@ -361,6 +395,16 @@ const ORDER_OBJECT_SCHEMA = {
   },
   additionalProperties: false,
 } as const;
+const IGNORE_ORDER_OBJECT_SCHEMA: JSONSchema4 = {
+  type: "object",
+  properties: {
+    type: {
+      enum: ["ignore"],
+    },
+  },
+  required: ["type"],
+  additionalProperties: false,
+};
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -400,7 +444,12 @@ export default createRule("sort-keys", {
                             keyPattern: {
                               type: "string",
                             },
-                            order: ORDER_OBJECT_SCHEMA,
+                            order: {
+                              oneOf: [
+                                ORDER_OBJECT_SCHEMA,
+                                IGNORE_ORDER_OBJECT_SCHEMA,
+                              ],
+                            },
                           },
                           additionalProperties: false,
                         },
@@ -409,6 +458,7 @@ export default createRule("sort-keys", {
                     uniqueItems: true,
                   },
                   ORDER_OBJECT_SCHEMA,
+                  IGNORE_ORDER_OBJECT_SCHEMA,
                 ],
               },
               minKeys: {

--- a/tests/src/rules/sort-keys.ts
+++ b/tests/src/rules/sort-keys.ts
@@ -81,6 +81,60 @@ tester.run(
           language: "yml/yaml",
         },
 
+        // ignore
+        {
+          code: `{
+            "exports": {
+              ".": {
+                "require": "./index.cjs",
+                "import": "./index.js",
+                "types": "./index.d.ts"
+              }
+            },
+            "name": "example"
+          }`,
+          options: [
+            {
+              pathPattern: '^exports\\["\\."\\]$',
+              order: { type: "ignore" },
+            },
+            {
+              pathPattern: ".*",
+              order: { type: "asc" },
+            },
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+
+        // ignore nested order
+        {
+          code: `{
+            "a": 1,
+            "z": 2,
+            "b": 3
+          }`,
+          options: [
+            {
+              pathPattern: "^$",
+              order: [
+                {
+                  keyPattern: "^z$",
+                  order: { type: "ignore" },
+                },
+                {
+                  keyPattern: ".*",
+                  order: { type: "asc" },
+                },
+              ],
+            },
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+
         // nest
         {
           code: `
@@ -149,6 +203,114 @@ tester.run(
         },
       ],
       invalid: [
+        // Nested order patterns use first-match precedence.
+        {
+          code: `{
+            "a": 1,
+            "z": 2,
+            "b": 3
+          }`,
+          output: `{
+            "a": 1,
+            "b": 3,
+            "z": 2
+          }`,
+          options: [
+            {
+              pathPattern: "^$",
+              order: [
+                {
+                  keyPattern: ".*",
+                  order: { type: "asc" },
+                },
+                {
+                  keyPattern: "^z$",
+                  order: { type: "ignore" },
+                },
+              ],
+            },
+          ],
+          errors: [
+            "Expected mapping keys to be in specified order. 'z' should be after 'b'.",
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+        {
+          code: `b: 1
+z: 2
+a: 3
+`,
+          output: `z: 2
+a: 3
+b: 1
+`,
+          options: [
+            {
+              pathPattern: "^$",
+              order: [
+                {
+                  keyPattern: "^z$",
+                  order: { type: "ignore" },
+                },
+                {
+                  keyPattern: ".*",
+                  order: { type: "asc" },
+                },
+              ],
+            },
+          ],
+          errors: [
+            "Expected mapping keys to be in specified order. 'b' should be after 'a'.",
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+        {
+          code: `{
+            "dependencies": {
+              "z": "1.0.0",
+              "a": "1.0.0"
+            },
+            "exports": {
+              ".": {
+                "require": "./index.cjs",
+                "types": "./index.d.ts"
+              }
+            }
+          }`,
+          output: `{
+            "dependencies": {
+              "a": "1.0.0",
+              "z": "1.0.0"
+            },
+            "exports": {
+              ".": {
+                "require": "./index.cjs",
+                "types": "./index.d.ts"
+              }
+            }
+          }`,
+          options: [
+            {
+              pathPattern: '^exports\\["\\."\\]$',
+              order: { type: "ignore" },
+            },
+            {
+              pathPattern: ".*",
+              order: { type: "asc" },
+            },
+          ],
+          errors: [
+            "Expected mapping keys to be in ascending order. 'z' should be after 'a'.",
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+
         // package.json
         {
           code: `


### PR DESCRIPTION
This adds `{ type: "ignore" }` to pattern-based `yml/sort-keys` options, matching the behavior introduced in ota-meshi/eslint-plugin-jsonc#526. A matching path can preserve its mapping order while later fallback options continue sorting elsewhere, and nested key patterns can exclude selected keys with the existing first-match precedence.
