### PR TITLE
Fix sort-keys behavior around ignored pairs

### DIFF
--- a/.changeset/fair-anchors-sort.md
+++ b/.changeset/fair-anchors-sort.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-yml": patch
+---
+
+Fix `yml/sort-keys` autofixes that reorder YAML anchors and aliases across ignored pairs.

--- a/.changeset/quiet-groups-rest.md
+++ b/.changeset/quiet-groups-rest.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-yml": patch
+---
+
+Fix `yml/sort-keys` line-separated groups that begin with ignored pairs.

--- a/src/rules/sort-keys.ts
+++ b/src/rules/sort-keys.ts
@@ -629,6 +629,22 @@ export default createRule("sort-keys", {
             [result[prevIndex], result[nextIndex]] = [next, prev];
             return result;
           }
+          // Neither pair can move directly across every ignored pair. If the
+          // ignored pairs can be split between them, keep the intended key
+          // order so that the existing target selection can choose one of the
+          // safe local moves.
+          const moveDownBarrierIndex = between.findIndex((element) =>
+            shouldKeepOrder(prev, element),
+          );
+          if (
+            moveDownBarrierIndex > 0 &&
+            between
+              .slice(moveDownBarrierIndex)
+              .every((element) => !shouldKeepOrder(element, next))
+          ) {
+            [result[prevIndex], result[nextIndex]] = [next, prev];
+            return result;
+          }
         }
       } while (swapped);
       return result;

--- a/src/rules/sort-keys.ts
+++ b/src/rules/sort-keys.ts
@@ -570,7 +570,6 @@ export default createRule("sort-keys", {
       let prev: YAMLPairData | null = null;
       for (const pair of pairs) {
         if (
-          !ignore(pair, option) &&
           prev &&
           option.allowLineSeparatedGroups &&
           hasBlankLine(prev, pair)
@@ -689,7 +688,6 @@ export default createRule("sort-keys", {
           .slice(0, index)
           .find(
             (prev, i, prevPairs) =>
-              !ignore(prev, option) &&
               shouldAfterPairs.includes(prev) &&
               prevPairs.slice(i).every((pp) => !shouldKeepOrder(pp, pair)),
           );
@@ -702,7 +700,6 @@ export default createRule("sort-keys", {
           .slice(index + 1)
           .find(
             (next, i, nextPairs) =>
-              !ignore(next, option) &&
               shouldBeforePairs.includes(next) &&
               nextPairs
                 .slice(0, i + 1)
@@ -793,12 +790,8 @@ export default createRule("sort-keys", {
         let lastTarget: YAMLPairData | null = null;
         for (let index = pairIndex + 1; index < pairs.length; index++) {
           const element = pairs[index];
-          if (ignore(element, option)) {
-            if (shouldKeepOrder(pair, element)) return lastTarget;
-            continue;
-          }
           if (
-            option.isValidOrder(element, pair) &&
+            (ignore(element, option) || option.isValidOrder(element, pair)) &&
             !shouldKeepOrder(pair, element)
           ) {
             lastTarget = element;
@@ -842,12 +835,8 @@ export default createRule("sort-keys", {
         let lastTarget: YAMLPairData | null = null;
         for (let index = pairIndex - 1; index >= 0; index--) {
           const element = pairs[index];
-          if (ignore(element, option)) {
-            if (shouldKeepOrder(element, pair)) return lastTarget;
-            continue;
-          }
           if (
-            option.isValidOrder(pair, element) &&
+            (ignore(element, option) || option.isValidOrder(pair, element)) &&
             !shouldKeepOrder(element, pair)
           ) {
             lastTarget = element;

--- a/src/rules/sort-keys.ts
+++ b/src/rules/sort-keys.ts
@@ -569,11 +569,8 @@ export default createRule("sort-keys", {
       let group: YAMLPairData[] = [];
       let prev: YAMLPairData | null = null;
       for (const pair of pairs) {
-        if (ignore(pair, option)) {
-          prev = pair;
-          continue;
-        }
         if (
+          !ignore(pair, option) &&
           prev &&
           option.allowLineSeparatedGroups &&
           hasBlankLine(prev, pair)
@@ -593,26 +590,46 @@ export default createRule("sort-keys", {
     }
 
     /**
-     * Sort pairs by bubble sort.
+     * Build a sort target while retaining ignored pairs for anchor and alias
+     * safety checks.
      */
-    function bubbleSort(pairs: YAMLPairData[], option: ParsedOption) {
-      const l = pairs.length;
+    function buildSafeSortTarget(pairs: YAMLPairData[], option: ParsedOption) {
       const result = [...pairs];
       let swapped: boolean;
       do {
         swapped = false;
-        for (let nextIndex = 1; nextIndex < l; nextIndex++) {
-          const prevIndex = nextIndex - 1;
-          if (
-            option.isValidOrder(result[prevIndex], result[nextIndex]) ||
-            shouldKeepOrder(result[prevIndex], result[nextIndex])
-          )
+        for (let nextIndex = 1; nextIndex < result.length; nextIndex++) {
+          const next = result[nextIndex];
+          if (ignore(next, option)) continue;
+
+          // Ignored pairs do not participate in key ordering, but they must
+          // remain between sortable pairs so that crossing them can be checked.
+          let prevIndex = nextIndex - 1;
+          while (prevIndex >= 0 && ignore(result[prevIndex], option)) {
+            prevIndex--;
+          }
+          if (prevIndex < 0) continue;
+
+          const prev = result[prevIndex];
+          if (option.isValidOrder(prev, next) || shouldKeepOrder(prev, next)) {
             continue;
-          [result[prevIndex], result[nextIndex]] = [
-            result[nextIndex],
-            result[prevIndex],
-          ];
-          swapped = true;
+          }
+
+          const between = result.slice(prevIndex + 1, nextIndex);
+          // Prefer moving `next` before `prev` when it can safely cross every
+          // ignored pair between them, as in a normal bubble-sort swap.
+          if (between.every((element) => !shouldKeepOrder(element, next))) {
+            [result[prevIndex], result[nextIndex]] = [next, prev];
+            swapped = true;
+            continue;
+          }
+          // If `next` cannot move up, the same ordering can be reached by
+          // moving `prev` down. Return after this swap so that the edit script
+          // preserves that safe direction; later fix passes sort the rest.
+          if (between.every((element) => !shouldKeepOrder(prev, element))) {
+            [result[prevIndex], result[nextIndex]] = [next, prev];
+            return result;
+          }
         }
       } while (swapped);
       return result;
@@ -620,10 +637,17 @@ export default createRule("sort-keys", {
 
     /**
      * Verify for pairs order
+     * @param pairs The pairs to verify. These pairs include some that should be ignored.
+     * @param option The option for the current mapping.
      */
     function verifyPairs(pairs: YAMLPairData[], option: ParsedOption) {
-      const sorted = bubbleSort(pairs, option);
-      const editScript = calcShortestEditScript(pairs, sorted);
+      const sorted = buildSafeSortTarget(pairs, option);
+      const editScript = calcShortestEditScript(
+        pairs.filter((pair) => !ignore(pair, option)),
+        sorted.filter((pair) => !ignore(pair, option)),
+      );
+
+      let hasReport = false;
       for (let index = 0; index < editScript.length; index++) {
         const edit = editScript[index];
         if (edit.type !== "delete") continue;
@@ -640,45 +664,104 @@ export default createRule("sort-keys", {
             // should not happen
             continue;
           }
-          context.report({
-            loc: edit.a.reportLoc,
-            messageId: "shouldBeAfter",
-            data: {
-              thisName: edit.a.name,
-              targetName: target.name,
-              orderText: option.orderText,
-            },
-            *fix(fixer) {
-              if (edit.a.mapping.node.style === "flow") {
-                yield* fixToMoveDownForFlow(fixer, edit.a, target);
-              } else {
-                yield* fixToMoveDownForBlock(fixer, edit.a, target);
-              }
-            },
-          });
+          reportShouldBeAfter(edit.a, target);
         } else {
           const target = findInsertBeforeTarget(edit.a, insertEditIndex);
           if (!target) {
             // should not happen
             continue;
           }
-          context.report({
-            loc: edit.a.reportLoc,
-            messageId: "shouldBeBefore",
-            data: {
-              thisName: edit.a.name,
-              targetName: target.name,
-              orderText: option.orderText,
-            },
-            *fix(fixer) {
-              if (edit.a.mapping.node.style === "flow") {
-                yield* fixToMoveUpForFlow(fixer, edit.a, target);
-              } else {
-                yield* fixToMoveUpForBlock(fixer, edit.a, target);
-              }
-            },
-          });
+          reportShouldBeBefore(edit.a, target);
         }
+      }
+
+      if (hasReport) return;
+      if (editScript.every((e) => e.type === "common")) return;
+
+      // An ordering error was detected,
+      // but the shortest edit script could not determine a safe reordering.
+
+      for (const [index, pair] of pairs.entries()) {
+        if (ignore(pair, option)) continue;
+        const sortedIndex = sorted.indexOf(pair);
+        const shouldAfterPairs = sorted.slice(sortedIndex + 1);
+        const shouldBeBeforeTarget = pairs
+          .slice(0, index)
+          .find(
+            (prev, i, prevPairs) =>
+              !ignore(prev, option) &&
+              shouldAfterPairs.includes(prev) &&
+              prevPairs.slice(i).every((pp) => !shouldKeepOrder(pp, pair)),
+          );
+        if (shouldBeBeforeTarget) {
+          reportShouldBeBefore(pair, shouldBeBeforeTarget);
+          return;
+        }
+        const shouldBeforePairs = sorted.slice(0, sortedIndex);
+        const shouldBeAfterTarget = pairs
+          .slice(index + 1)
+          .find(
+            (next, i, nextPairs) =>
+              !ignore(next, option) &&
+              shouldBeforePairs.includes(next) &&
+              nextPairs
+                .slice(0, i + 1)
+                .every((nn) => !shouldKeepOrder(pair, nn)),
+          );
+        if (shouldBeAfterTarget) {
+          reportShouldBeAfter(pair, shouldBeAfterTarget);
+          return;
+        }
+      }
+
+      /**
+       * Report that the given pair should be after the target pair.
+       * @param pair The pair that should be after the target.
+       * @param target The target pair that the given pair should be after.
+       */
+      function reportShouldBeAfter(pair: YAMLPairData, target: YAMLPairData) {
+        hasReport = true;
+        context.report({
+          loc: pair.reportLoc,
+          messageId: "shouldBeAfter",
+          data: {
+            thisName: pair.name,
+            targetName: target.name,
+            orderText: option.orderText,
+          },
+          *fix(fixer) {
+            if (pair.mapping.node.style === "flow") {
+              yield* fixToMoveDownForFlow(fixer, pair, target);
+            } else {
+              yield* fixToMoveDownForBlock(fixer, pair, target);
+            }
+          },
+        });
+      }
+
+      /**
+       * Report that the given pair should be before the target pair.
+       * @param pair The pair that should be before the target.
+       * @param target The target pair that the given pair should be before.
+       */
+      function reportShouldBeBefore(pair: YAMLPairData, target: YAMLPairData) {
+        hasReport = true;
+        context.report({
+          loc: pair.reportLoc,
+          messageId: "shouldBeBefore",
+          data: {
+            thisName: pair.name,
+            targetName: target.name,
+            orderText: option.orderText,
+          },
+          *fix(fixer) {
+            if (pair.mapping.node.style === "flow") {
+              yield* fixToMoveUpForFlow(fixer, pair, target);
+            } else {
+              yield* fixToMoveUpForBlock(fixer, pair, target);
+            }
+          },
+        });
       }
 
       /**
@@ -710,6 +793,10 @@ export default createRule("sort-keys", {
         let lastTarget: YAMLPairData | null = null;
         for (let index = pairIndex + 1; index < pairs.length; index++) {
           const element = pairs[index];
+          if (ignore(element, option)) {
+            if (shouldKeepOrder(pair, element)) return lastTarget;
+            continue;
+          }
           if (
             option.isValidOrder(element, pair) &&
             !shouldKeepOrder(pair, element)
@@ -755,6 +842,10 @@ export default createRule("sort-keys", {
         let lastTarget: YAMLPairData | null = null;
         for (let index = pairIndex - 1; index >= 0; index--) {
           const element = pairs[index];
+          if (ignore(element, option)) {
+            if (shouldKeepOrder(element, pair)) return lastTarget;
+            continue;
+          }
           if (
             option.isValidOrder(pair, element) &&
             !shouldKeepOrder(element, pair)

--- a/tests/src/rules/sort-keys.ts
+++ b/tests/src/rules/sort-keys.ts
@@ -135,6 +135,34 @@ tester.run(
           language: "yml/yaml",
         },
 
+        // Ignore line-separated groups.
+        {
+          code: `c: 1
+
+z: 2
+b: 3
+`,
+          options: [
+            {
+              pathPattern: "^$",
+              allowLineSeparatedGroups: true,
+              order: [
+                {
+                  keyPattern: "^z$",
+                  order: { type: "ignore" },
+                },
+                {
+                  keyPattern: ".*",
+                  order: { type: "asc" },
+                },
+              ],
+            },
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+
         // nest
         {
           code: `
@@ -269,40 +297,6 @@ b: 1
           language: "yml/yaml",
         },
         {
-          code: `c: 1
-
-z: 2
-b: 3
-`,
-          output: `z: 2
-b: 3
-c: 1
-
-`,
-          options: [
-            {
-              pathPattern: "^$",
-              allowLineSeparatedGroups: true,
-              order: [
-                {
-                  keyPattern: "^z$",
-                  order: { type: "ignore" },
-                },
-                {
-                  keyPattern: ".*",
-                  order: { type: "asc" },
-                },
-              ],
-            },
-          ],
-          errors: [
-            "Expected mapping keys to be in specified order. 'c' should be after 'b'.",
-          ],
-          // @ts-expect-error -- type bug?
-          plugins: { yml: plugin },
-          language: "yml/yaml",
-        },
-        {
           code: `
 b: &x 1
 z: *x
@@ -412,41 +406,6 @@ c: 2
           ],
           errors: [
             "Expected mapping keys to be in specified order. 'c' should be after 'a'.",
-          ],
-          // @ts-expect-error -- type bug?
-          plugins: { yml: plugin },
-          language: "yml/yaml",
-        },
-        {
-          code: `
-d: &x 1
-z: 0
-y: *x
-a: 2
-`,
-          output: `
-a: 2
-d: &x 1
-z: 0
-y: *x
-`,
-          options: [
-            {
-              pathPattern: "^$",
-              order: [
-                {
-                  keyPattern: "^[yz]$",
-                  order: { type: "ignore" },
-                },
-                {
-                  keyPattern: ".*",
-                  order: { type: "asc" },
-                },
-              ],
-            },
-          ],
-          errors: [
-            "Expected mapping keys to be in specified order. 'a' should be before 'd'.",
           ],
           // @ts-expect-error -- type bug?
           plugins: { yml: plugin },

--- a/tests/src/rules/sort-keys.ts
+++ b/tests/src/rules/sort-keys.ts
@@ -135,34 +135,6 @@ tester.run(
           language: "yml/yaml",
         },
 
-        // Ignore line-separated groups.
-        {
-          code: `c: 1
-
-z: 2
-b: 3
-`,
-          options: [
-            {
-              pathPattern: "^$",
-              allowLineSeparatedGroups: true,
-              order: [
-                {
-                  keyPattern: "^z$",
-                  order: { type: "ignore" },
-                },
-                {
-                  keyPattern: ".*",
-                  order: { type: "asc" },
-                },
-              ],
-            },
-          ],
-          // @ts-expect-error -- type bug?
-          plugins: { yml: plugin },
-          language: "yml/yaml",
-        },
-
         // nest
         {
           code: `
@@ -297,6 +269,42 @@ b: 1
           language: "yml/yaml",
         },
         {
+          code: `x: 0
+
+z: 0
+c: 1
+b: 2
+`,
+          output: `x: 0
+
+z: 0
+b: 2
+c: 1
+`,
+          options: [
+            {
+              pathPattern: "^$",
+              allowLineSeparatedGroups: true,
+              order: [
+                {
+                  keyPattern: "^z$",
+                  order: { type: "ignore" },
+                },
+                {
+                  keyPattern: ".*",
+                  order: { type: "asc" },
+                },
+              ],
+            },
+          ],
+          errors: [
+            "Expected mapping keys to be in specified order. 'c' should be after 'b'.",
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+        {
           code: `
 b: &x 1
 z: *x
@@ -406,6 +414,70 @@ c: 2
           ],
           errors: [
             "Expected mapping keys to be in specified order. 'c' should be after 'a'.",
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+        {
+          code: `
+b: 0
+y: &x 1
+z: 0
+c: 0
+a: *x
+`,
+          output: `
+b: 0
+y: &x 1
+a: *x
+z: 0
+c: 0
+`,
+          options: [
+            {
+              pathPattern: "^$",
+              order: [
+                {
+                  keyPattern: "^[yz]$",
+                  order: { type: "ignore" },
+                },
+                {
+                  keyPattern: ".*",
+                  order: { type: "asc" },
+                },
+              ],
+            },
+          ],
+          errors: [
+            "Expected mapping keys to be in specified order. 'a' should be before 'z'.",
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+        {
+          code: `{ a: 0, c: &x 1, y: 0, z: *x, b: 0 }
+`,
+          output: `{ a: 0, y: 0, c: &x 1, z: *x, b: 0 }
+`,
+          options: [
+            {
+              pathPattern: "^$",
+              order: [
+                {
+                  keyPattern: "^[yz]$",
+                  order: { type: "ignore" },
+                },
+                {
+                  keyPattern: ".*",
+                  order: { type: "asc" },
+                },
+              ],
+            },
+          ],
+          errors: [
+            "Expected mapping keys to be in specified order. 'c' should be after 'y'.",
           ],
           // @ts-expect-error -- type bug?
           plugins: { yml: plugin },

--- a/tests/src/rules/sort-keys.ts
+++ b/tests/src/rules/sort-keys.ts
@@ -269,6 +269,190 @@ b: 1
           language: "yml/yaml",
         },
         {
+          code: `c: 1
+
+z: 2
+b: 3
+`,
+          output: `z: 2
+b: 3
+c: 1
+
+`,
+          options: [
+            {
+              pathPattern: "^$",
+              allowLineSeparatedGroups: true,
+              order: [
+                {
+                  keyPattern: "^z$",
+                  order: { type: "ignore" },
+                },
+                {
+                  keyPattern: ".*",
+                  order: { type: "asc" },
+                },
+              ],
+            },
+          ],
+          errors: [
+            "Expected mapping keys to be in specified order. 'c' should be after 'b'.",
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+        {
+          code: `
+b: &x 1
+z: *x
+a: 2
+`,
+          output: `
+a: 2
+b: &x 1
+z: *x
+`,
+          options: [
+            {
+              pathPattern: "^$",
+              order: [
+                {
+                  keyPattern: "^z$",
+                  order: { type: "ignore" },
+                },
+                {
+                  keyPattern: ".*",
+                  order: { type: "asc" },
+                },
+              ],
+            },
+          ],
+          errors: [
+            "Expected mapping keys to be in specified order. 'a' should be before 'b'.",
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+        {
+          code: `{ b: &x 1, z: *x, a: 2 }
+`,
+          output: `{ a: 2, b: &x 1, z: *x }
+`,
+          options: [
+            {
+              pathPattern: "^$",
+              order: ["a", "b"],
+            },
+          ],
+          errors: [
+            "Expected mapping keys to be in specified order. 'a' should be before 'b'.",
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+        {
+          code: `b: 0
+z: &x 1
+a: *x
+`,
+          output: `z: &x 1
+a: *x
+b: 0
+`,
+          options: [
+            {
+              pathPattern: "^$",
+              order: [
+                {
+                  keyPattern: "^z$",
+                  order: { type: "ignore" },
+                },
+                {
+                  keyPattern: ".*",
+                  order: { type: "asc" },
+                },
+              ],
+            },
+          ],
+          errors: [
+            "Expected mapping keys to be in specified order. 'b' should be after 'a'.",
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+        {
+          code: `b: 1
+c: 2
+z: &x 3
+a: *x
+`,
+          output: `b: 1
+z: &x 3
+a: *x
+c: 2
+`,
+          options: [
+            {
+              pathPattern: "^$",
+              order: [
+                {
+                  keyPattern: "^z$",
+                  order: { type: "ignore" },
+                },
+                {
+                  keyPattern: ".*",
+                  order: { type: "asc" },
+                },
+              ],
+            },
+          ],
+          errors: [
+            "Expected mapping keys to be in specified order. 'c' should be after 'a'.",
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+        {
+          code: `
+d: &x 1
+z: 0
+y: *x
+a: 2
+`,
+          output: `
+a: 2
+d: &x 1
+z: 0
+y: *x
+`,
+          options: [
+            {
+              pathPattern: "^$",
+              order: [
+                {
+                  keyPattern: "^[yz]$",
+                  order: { type: "ignore" },
+                },
+                {
+                  keyPattern: ".*",
+                  order: { type: "asc" },
+                },
+              ],
+            },
+          ],
+          errors: [
+            "Expected mapping keys to be in specified order. 'a' should be before 'd'.",
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+        {
           code: `{
             "dependencies": {
               "z": "1.0.0",

--- a/tests/src/rules/sort-keys.ts
+++ b/tests/src/rules/sort-keys.ts
@@ -135,6 +135,90 @@ tester.run(
           language: "yml/yaml",
         },
 
+        // Ignore with line-separated groups
+        {
+          code: `c: 1
+
+z: 0
+b: 2
+`,
+          options: [
+            {
+              pathPattern: "^$",
+              allowLineSeparatedGroups: true,
+              order: [
+                {
+                  keyPattern: "^z$",
+                  order: { type: "ignore" },
+                },
+                {
+                  keyPattern: ".*",
+                  order: { type: "asc" },
+                },
+              ],
+            },
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+
+        // No safe move across ignored anchor and alias pairs
+        {
+          code: `b: &x 0
+y: *x
+z: &q 0
+a: *q
+`,
+          options: [
+            {
+              pathPattern: "^$",
+              order: [
+                {
+                  keyPattern: "^[yz]$",
+                  order: { type: "ignore" },
+                },
+                {
+                  keyPattern: ".*",
+                  order: { type: "asc" },
+                },
+              ],
+            },
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+
+        // No converging local move across ignored anchor and alias pairs
+        {
+          code: `b: &p 1
+w: 0
+x:
+  use: *p
+  define: &q 1
+a: *q
+`,
+          options: [
+            {
+              pathPattern: "^$",
+              order: [
+                {
+                  keyPattern: "^[wx]$",
+                  order: { type: "ignore" },
+                },
+                {
+                  keyPattern: ".*",
+                  order: { type: "asc" },
+                },
+              ],
+            },
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+
         // nest
         {
           code: `
@@ -478,6 +562,76 @@ c: 0
           ],
           errors: [
             "Expected mapping keys to be in specified order. 'c' should be after 'y'.",
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+        {
+          code: `b: &p 1
+x: &q 1
+y: *p
+a: *q
+`,
+          output: `x: &q 1
+b: &p 1
+y: *p
+a: *q
+`,
+          options: [
+            {
+              pathPattern: "^$",
+              order: [
+                {
+                  keyPattern: "^[xy]$",
+                  order: { type: "ignore" },
+                },
+                {
+                  keyPattern: ".*",
+                  order: { type: "asc" },
+                },
+              ],
+            },
+          ],
+          errors: [
+            "Expected mapping keys to be in specified order. 'b' should be after 'x'.",
+          ],
+          // @ts-expect-error -- type bug?
+          plugins: { yml: plugin },
+          language: "yml/yaml",
+        },
+        {
+          code: `c: &p 1
+z:
+  use: *p
+  define: &q 1
+b: *q
+a: 0
+`,
+          output: `c: &p 1
+z:
+  use: *p
+  define: &q 1
+a: 0
+b: *q
+`,
+          options: [
+            {
+              pathPattern: "^$",
+              order: [
+                {
+                  keyPattern: "^z$",
+                  order: { type: "ignore" },
+                },
+                {
+                  keyPattern: ".*",
+                  order: { type: "asc" },
+                },
+              ],
+            },
+          ],
+          errors: [
+            "Expected mapping keys to be in specified order. 'b' should be after 'a'.",
           ],
           // @ts-expect-error -- type bug?
           plugins: { yml: plugin },


### PR DESCRIPTION
`yml/sort-keys` excludes ignored pairs from key ordering, which also hid information needed when choosing a safe pair to move. Autofixes could therefore place an anchor after an ignored alias.

This change retains ignored pairs while building the sort target without making them participate in key ordering. The rule uses their anchor and alias relationships to choose a safe local movement, allowing subsequent fix passes to finish sorting.

Retaining those pairs also makes blank lines before ignored keys delimit `allowLineSeparatedGroups` groups, matching the physical YAML layout instead of comparing keys across the boundary.
